### PR TITLE
Rewrite the documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2018"
 description = "Simple macro to allow mutating instance with declarative flavor"
 categories = ["no-std"]
 keywords = ["macro"]
-authors = ["Alan Darmasaputra <kelerchian@gmail.com>"]
+authors = [
+    "Alan Darmasaputra <kelerchian@gmail.com>",
+    "Jonas Platte <jplatte@posteo.de>",
+]
 repository = "https://github.com/Kelerchian/assign"
 readme = "README.md"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,3 @@ authors = ["Alan Darmasaputra <kelerchian@gmail.com>"]
 repository = "https://github.com/Kelerchian/assign"
 readme = "README.md"
 license-file = "LICENSE"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]


### PR DESCRIPTION
Hey @Kelerchian, I've taken some time to work on the documentation; it ended up basically being a rewrite (though I left some wording intact and your previous example is still basically there). Does this look good to you?

I've got one more change planned for this crate, and that is supporting field init shorthand. After that, I'd like to make a 1.1.0 release if you don't mind.