### PR TITLE
Shorthand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,12 +114,18 @@
 #[macro_export]
 macro_rules! assign {
     ($initial_value:expr, {
-        $($field:ident: $value:expr),+ $(,)?
+        $( $field:ident $( : $value:expr )? ),+ $(,)?
     }) => ({
         let mut item = $initial_value;
-        $( item.$field = $value; )+
+        $( $crate::assign!(@assign item $field $( : $value )?); )+
         item
-    })
+    });
+    (@assign $item:ident $field:ident : $value:expr) => {
+        $item.$field = $value;
+    };
+    (@assign $item:ident $field:ident) => {
+        $item.$field = $field;
+    };
 }
 
 #[cfg(test)]
@@ -149,8 +155,26 @@ mod tests {
     }
 
     #[test]
+    fn shorthand() {
+        let def = SomeStruct::default();
+        let a = 5;
+        let res = assign!(def, { a });
+
+        assert_eq!(
+            res,
+            SomeStruct {
+                a: 5,
+                b: None,
+                c: None
+            }
+        );
+    }
+
+    #[test]
     fn field_expr_inference() {
+        let b = 0.0.into();
         let res = assign!(SomeStruct::default(), {
+            b,
             c: 1.into(),
         });
 
@@ -158,7 +182,7 @@ mod tests {
             res,
             SomeStruct {
                 a: 0,
-                b: None,
+                b: Some(0.0),
                 c: Some(1)
             }
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,3 +121,46 @@ macro_rules! assign {
         item
     })
 }
+
+#[cfg(test)]
+mod tests {
+    #[derive(Debug, Default, PartialEq)]
+    struct SomeStruct {
+        a: u32,
+        b: Option<f32>,
+        c: Option<u64>,
+    }
+
+    #[test]
+    fn basic() {
+        let res = assign!(SomeStruct::default(), {
+            a: 5,
+            b: None,
+        });
+
+        assert_eq!(
+            res,
+            SomeStruct {
+                a: 5,
+                b: None,
+                c: None
+            }
+        );
+    }
+
+    #[test]
+    fn field_expr_inference() {
+        let res = assign!(SomeStruct::default(), {
+            c: 1.into(),
+        });
+
+        assert_eq!(
+            res,
+            SomeStruct {
+                a: 0,
+                b: None,
+                c: Some(1)
+            }
+        );
+    }
+}


### PR DESCRIPTION
So I wanted to add support for field init shorthand and it turned out to not be that easy. I still plan to do that in this PR, but wanted to know what you think about supporting tuples and tuple structs. Probably useless (same as supporting empty updates which would also only be a few characters change to support) but also doesn't seem to hurt?