### PR TITLE
Remove license-file from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ authors = [
 repository = "https://github.com/Kelerchian/assign"
 readme = "README.md"
 license = "MIT"
-license-file = "LICENSE"


### PR DESCRIPTION
It is redundant with license.